### PR TITLE
Handle string value of true for iam enablement

### DIFF
--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -299,7 +299,7 @@ function checkMessageHubCredentials(params) {
 }
 
 function verifyTriggerAuth(triggerURL, apiKey, isIamKey, iamUrl, rejectNotFound) {
-    if (isIamKey === true) {
+    if (isIamKey === true || isIamKey === "true") {
         return new itm({ 'iamApikey': apiKey, 'iamUrl': iamUrl }).getToken().then( token => common.verifyTriggerAuth(triggerURL, { bearer: token }));
     } else {
         var auth = apiKey.split(':');


### PR DESCRIPTION
The `trigger get` command does not work for IAM enabled triggers as `GET` requests to the feed's web action convert boolean values to string values.