### PR TITLE
Bump Kafka client version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:2.7.16
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka
-ENV LIBRDKAFKA_VERSION 1.2.0
+ENV LIBRDKAFKA_VERSION 1.3.0
 RUN git clone --depth 1 --branch v${LIBRDKAFKA_VERSION} https://github.com/edenhill/librdkafka.git librdkafka \
     && cd librdkafka \
     && ./configure \


### PR DESCRIPTION
Release notes: https://github.com/edenhill/librdkafka/releases?after=v1.4.0-PRE1