### PR TITLE
Lock werkzeug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV LIBRARY_PATH /usr/local/lib
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 RUN pip install gevent==1.1.2 flask==0.11.1 confluent-kafka==${LIBRDKAFKA_VERSION} \
-    requests==2.10.0 cloudant==2.5.0 psutil==5.0.0
+    requests==2.10.0 cloudant==2.5.0 psutil==5.0.0 werkzeug==0.16.1
 
 # while I expect these will be overridden during deployment, we might as well
 # set reasonable defaults


### PR DESCRIPTION
Newest version of werkzeug breaks flask. See https://github.com/pallets/werkzeug/issues/1714.