### PR TITLE
Remove CURL from built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@
 
 FROM python:2.7.16
 
+# Remove CURL as it is has constant security vulnerabilities and we don't use it
+RUN apt-get purge -y --auto-remove curl
+
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka


### PR DESCRIPTION
Remove CURL as it constantly causes the built images to be flag for security vulnerabilities whenever a new security problem is found in CURL.