### PR TITLE
Do not start a consumer for a disabled trigger

### DIFF
--- a/provider/database.py
+++ b/provider/database.py
@@ -60,7 +60,7 @@ class Database:
             self.client.disconnect()
             self.client = None
 
-    def disableTrigger(self, triggerFQN, status_code, message='Automatically disabled after receiving a {} status code when firing the trigger.'):
+    def disableTrigger(self, triggerFQN, status_code, message):
         try:
             document = self.database[triggerFQN]
 

--- a/provider/service.py
+++ b/provider/service.py
@@ -113,6 +113,7 @@ class Service (Thread):
                             self.createAndRunConsumer(document)
                         else:
                             logging.info("[{}] Found a new trigger, but is assigned to another worker: {}".format(change["id"], document["worker"]))
+
                     else:
                         existingConsumer = self.consumers.getConsumerForTrigger(change["id"])
 
@@ -181,10 +182,12 @@ class Service (Thread):
         # Create a representation for this trigger, even if it is disabled
         # This allows it to appear in /health as well as allow it to be deleted
         # Creating this object is lightweight and does not initialize any connections
+
+        # TODO: don't want to run the process...
         consumer = Consumer(triggerFQN, doc)
         self.consumers.addConsumerForTrigger(triggerFQN, consumer)
 
-        if self.__isTriggerDocActive(doc):
+        if self.__isTriggerDocActive(doc) and consumer.desiredState() != Consumer.State.Disabled:
             logging.info('[{}] Trigger was determined to be active, starting...'.format(triggerFQN))
             consumer.start()
         else:


### PR DESCRIPTION
When the provider starts, do not start a process for disabled triggers. Also, disable triggers that no longer have valid Kafka credentials. 