### PR TITLE
add sys.exit() to exception handler to prevent trace_leak thread getting

### DIFF
--- a/provider/app.py
+++ b/provider/app.py
@@ -23,6 +23,7 @@ import os
 import tracemalloc
 import time
 import threading
+import sys
 
 from flask import Flask, jsonify
 from consumercollection import ConsumerCollection
@@ -126,6 +127,7 @@ def main():
 
     except Exception as ex:
         logging.error('During startup the main thread of kafka provider caught an exception: {}'.format(ex) )
+        sys.exit()
 
     ###################################################################
     # To investigate on memory leaks in kafka provider a tracing

--- a/provider/app.py
+++ b/provider/app.py
@@ -123,8 +123,7 @@ def main():
 
         port = int(os.getenv('PORT', 5000))
         server = WSGIServer(('', port), app, log=logging.getLogger())
-        server.serve_forever()
-
+        
     except Exception as ex:
         logging.error('During startup the main thread of kafka provider caught an exception: {}'.format(ex) )
         sys.exit()
@@ -136,6 +135,10 @@ def main():
     collect_memory_profile = threading.Thread(target=trace_leak)
     collect_memory_profile.start()
 
-
+    ############################################
+    # run HTTP server functionality in main thread
+    ############################################
+    server.serve_forever()
+    
 if __name__ == '__main__':
     main()

--- a/provider/app.py
+++ b/provider/app.py
@@ -123,8 +123,8 @@ def main():
 
         port = int(os.getenv('PORT', 5000))
         server = WSGIServer(('', port), app, log=logging.getLogger())
-        
     except Exception as ex:
+
         logging.error('During startup the main thread of kafka provider caught an exception: {}'.format(ex) )
         sys.exit()
 

--- a/provider/app.py
+++ b/provider/app.py
@@ -139,6 +139,6 @@ def main():
     # run HTTP server functionality in main thread
     ############################################
     server.serve_forever()
-    
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
add sys.exit() to exception handler to prevent trace_leak thread getting started.