### PR TITLE
Fix psutilsversion mar23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV LIBRARY_PATH /usr/local/lib
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 RUN pip install gevent==20.9.0 greenlet==1.1.3 flask==2.1.1 confluent-kafka==${LIBRDKAFKA_VERSION} \
-    requests==2.10.0 cloudant==2.5.0 psutil==5.0.0 pycryptodome==3.9.8  itsdangerous==2.0.1
+    requests==2.10.0 cloudant==2.5.0 psutil==5.9.4 pycryptodome==3.9.8  itsdangerous==2.0.1
 # while I expect these will be overridden during deployment, we might as well
 # set reasonable defaults
 ENV PORT 5000

--- a/provider/health.py
+++ b/provider/health.py
@@ -44,7 +44,7 @@ def getSwapMemory():
 
 
 def getVirtualMemory():
-    total, available, percent, used, free, active, inactive, buffers, cached, shared = psutil.virtual_memory()
+    total, available, percent, used, free, active, inactive, buffers, cached, shared, _ = psutil.virtual_memory()
     virtual_memory = {}
     virtual_memory['total'] = '%d MB' % (total / MEGABYTE)
     virtual_memory['available'] = '%d MB' % (available / MEGABYTE)


### PR DESCRIPTION
psutil version must be upgraded to version 5.9.4  to run on Ubuntu:20  nodes  and the /health code must be adapted to the API breaking code in  psutil