### PR TITLE
fix version for error with werkzeug pip module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ ENV CPLUS_INCLUDE_PATH /usr/local/include
 ENV LIBRARY_PATH /usr/local/lib
 ENV LD_LIBRARY_PATH /usr/local/lib
 
-RUN pip install gevent==20.9.0 greenlet==1.1.3 flask==2.1.1 confluent-kafka==${LIBRDKAFKA_VERSION} \
-    requests==2.10.0 cloudant==2.5.0 psutil==5.9.4 pycryptodome==3.9.8  itsdangerous==2.0.1
+COPY requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt &&  pip install confluent-kafka==${LIBRDKAFKA_VERSION}
+
 # while I expect these will be overridden during deployment, we might as well
 # set reasonable defaults
 ENV PORT 5000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+gevent==20.9.0
+greenlet==1.1.3
+flask==2.1.1
+requests==2.10.0
+cloudant==2.5.0 
+psutil==5.9.4
+pycryptodome==3.9.8
+itsdangerous==2.0.1 
+werkzeug==2.3.7


### PR DESCRIPTION
The kafka provider written in python is using a fix version of the flask module ( 2.1.1.) . This module has an inner dependency to the  "werkzeug" module ( >=2.x.x ) . But the newest werkzeug 3.0.0  is not compatible  to the old flask.  So a fix version of werkzeub must be added to the dockerfile building the kafka provider 